### PR TITLE
Adding ability to specify action state in sync_action and find_action

### DIFF
--- a/dartclient/__init__.py
+++ b/dartclient/__init__.py
@@ -20,4 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-__version__ = '1.1.dev2'
+__version__ = '1.1.dev3'

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -11,6 +11,10 @@ install it from source:
 
 * pip install git+https://github.com/RetailMeNotSandbox/dartclient.git
 
+or by adding the following to your requirements.txt file:
+
+* -e git+https://github.com/RetailMeNotSandbox/dartclient.git#egg=dartclient
+
 Connecting to Dart
 ------------------
 


### PR DESCRIPTION
This fixes the following error when performing a sync_action with an EMR action with state TEMPLATE after the workflow has been executed:

`More than one action object found.`

